### PR TITLE
Bump JSC intl version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.abner.fastdev.android'
-version '0.1.8'
+version '0.2.0'
 
 buildscript {
     repositories {

--- a/download-jsc/build.gradle
+++ b/download-jsc/build.gradle
@@ -49,9 +49,27 @@ task downloadJscNewest(type: Download) {
     }
 }
 
+task downloadJscNewestIntl(type: Download) {
+
+    src 'https://registry.npmjs.org/jsc-android/-/jsc-android-294992.0.0.tgz'
+    dest new File("${projectDir}/jsc-download-package")
+    connectTimeout 25000
+    onlyIfNewer true
+    doLast {
+
+        copy {
+            from tarTree(resources.gzip(new File("${projectDir}/jsc-download-package/jsc-android-294992.0.0.tgz")))
+            into "${getProjectDir()}/libs/294992.0.0"
+
+        }
+    }
+}
+
 build.dependsOn downloadJsc
 
 downloadJsc.dependsOn downloadJscNewest
+
+downloadJsc.dependsOn downloadJscNewestIntl
 
 
 task replaceAndroidJsc(type: Copy) {

--- a/jsc-intl/build.gradle
+++ b/jsc-intl/build.gradle
@@ -16,24 +16,15 @@ buildscript {
 repositories {
     google()
     jcenter()
-    maven {
-        // Local Maven repo containing AARs with JSC library built for Android
-        url "$projectDir/../download-jsc/libs/245459.0.0/package/dist"
-    }
      maven {
         // Local Maven repo containing AARs with JSC library built for Android
-        url "$projectDir/../download-jsc/libs/250230.2.1/package/dist"
+        url "$projectDir/../download-jsc/libs/294992.0.0/package/dist"
     }
 }
 
 apply plugin: 'com.kezong.fat-aar'
 
 android {
-
-//    packagingOptions {
-//        pickFirst '**/libjsc.so'
-//        pickFirst '**/libc++_shared.so'
-//    }
     defaultConfig {
         externalNativeBuild {
             cmake {
@@ -47,6 +38,5 @@ android {
 }
 
 dependencies {
-    embed "org.webkit:android-jsc-intl:r250230"
-    embed "org.webkit:android-jsc-cppruntime:r245459"
+    embed "org.webkit:android-jsc-intl:r294992"
 }


### PR DESCRIPTION
`jsc-android` no longer distributes the non-intl version because webkit itself does not. Thus I left the non-intl version untouched (outdated) and only changed the intl version. In the newest `jsc-android` distribution `cppruntime` is not included because it has been statically linked, thus we can remove it all together.

This version bump is a 3 year jump. Includes many new JS features as well as crucial bug fixes (one of which is deeply affecting our project)

Fixes #3